### PR TITLE
Highlight files with .vapi extensions.

### DIFF
--- a/Syntaxes/Vala.tmLanguage
+++ b/Syntaxes/Vala.tmLanguage
@@ -20,6 +20,7 @@
 	<key>fileTypes</key>
 	<array>
 		<string>vala</string>
+		<string>vapi</string>
 	</array>
 	<key>foldingStartMarker</key>
 	<string>(\{\s*(//.*)?$|^\s*// \{\{\{)</string>


### PR DESCRIPTION
Vala language bindings use the file extension .vapi and uses more or less exactly the same syntax as regular vala sources. This commits simply adds vapi to the vala syntax highlighting definition.

I should point out that this has only been tried out with Sublime Text 2. I don't know how textmate behaves.