### PR TITLE
Remove suspicious group inside type parameter character class

### DIFF
--- a/Syntaxes/Vala.tmLanguage
+++ b/Syntaxes/Vala.tmLanguage
@@ -863,7 +863,7 @@
 					<key>begin</key>
 					<string>\b((?:[a-z]\w*\.)*[A-Z]+\w*)&lt;</string>
 					<key>end</key>
-					<string>&gt;|[^\w\s,\?&lt;\[(?:[,]+)\]]</string>
+					<string>&gt;|[^\w\s,\?&lt;\[\]]</string>
 					<key>name</key>
 					<string>storage.type.generic.vala</string>
 					<key>patterns</key>


### PR DESCRIPTION
This group was added in 06c314bdb1d876e6dd4d3df64458c4462e6d575e. I'm not sure what the intent was here. Oniguruma parses `(?:+)` as regular characters. `[,]` is parsed as a nested character class and so is equivalent to just a bare comma. So the addition of this group to the character class really just means that parentheses and colons are now part of the (negated) class. I don't believe this was the intent, so I've removed the group entirely.
